### PR TITLE
Technical Response to Audio and CTV Requirements: add exit_point stage

### DIFF
--- a/endpoints/openrtb2/auction.go
+++ b/endpoints/openrtb2/auction.go
@@ -376,18 +376,48 @@ func sendAuctionResponse(
 		}
 	}
 
+	res, headers, err := hookExecutor.ExecuteExitPointStage(request, response)
+	if err != nil {
+		labels.RequestStatus = metrics.RequestStatusNetworkErr
+		ao.Errors = append(ao.Errors, fmt.Errorf("/openrtb2/auction Failed to ExecuteExitPointStage: %w", err))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if headers != nil {
+		for key, vals := range headers {
+			for i, val := range vals {
+				if i == 0 {
+					// overwrite existing setting
+					w.Header().Set(key, val)
+				} else {
+					// add additional values to existing key
+					w.Header().Add(key, val)
+				}
+			}
+		}
+	}
+
+	if res == nil {
+		res = response
+	}
+	if resRaw, ok := res.(json.RawMessage); ok {
+		if _, e := w.Write(resRaw); err != nil {
+			labels.RequestStatus = metrics.RequestStatusNetworkErr
+			ao.Errors = append(ao.Errors, fmt.Errorf("/openrtb2/auction Failed to write raw response: %w", e))
+		}
+		return labels, ao
+	}
+
 	// Fixes #231
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
 
-	w.Header().Set("Content-Type", "application/json")
-
 	// If an error happens when encoding the response, there isn't much we can do.
 	// If we've sent _any_ bytes, then Go would have sent the 200 status code first.
 	// That status code can't be un-sent... so the best we can do is log the error.
-	if err := enc.Encode(response); err != nil {
+	if err := enc.Encode(res); err != nil {
 		labels.RequestStatus = metrics.RequestStatusNetworkErr
-		ao.Errors = append(ao.Errors, fmt.Errorf("/openrtb2/auction Failed to send response: %v", err))
+		ao.Errors = append(ao.Errors, fmt.Errorf("/openrtb2/auction Failed to send response: %w", err))
 	}
 
 	return labels, ao

--- a/hooks/empty_plan.go
+++ b/hooks/empty_plan.go
@@ -36,3 +36,7 @@ func (e EmptyPlanBuilder) PlanForAllProcessedBidResponsesStage(endpoint string, 
 func (e EmptyPlanBuilder) PlanForAuctionResponseStage(endpoint string, account *config.Account) Plan[hookstage.AuctionResponse] {
 	return nil
 }
+
+func (e EmptyPlanBuilder) PlanForExitPointStage(endpoint string, account *config.Account) Plan[hookstage.ExitPoint] {
+	return nil
+}

--- a/hooks/hookstage/exitpoint.go
+++ b/hooks/hookstage/exitpoint.go
@@ -1,0 +1,39 @@
+package hookstage
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/prebid/openrtb/v20/openrtb2"
+	"github.com/prebid/prebid-server/v3/config"
+)
+
+// ExitPoint hooks are invoked only for "/openrtb2/auction"
+// just before openrtb2.BidResponse is serialized and passed to
+// http.ResponseWriter.
+//
+// At this stage, only a single hook can be declared,
+// cause otherwise the return result becomes unpredictable.
+//
+// The code can return modified openrtb2.BidResponse or any
+// other Go type declared by module and mapped to
+// openrtb2.BidResponse
+//
+// The response must be pointer.
+type ExitPoint interface {
+	HandleExitPointHook(
+		context.Context,
+		ModuleInvocationContext,
+		ExitPointPayload,
+	) (HookResult[ExitPointPayload], error)
+}
+
+// ExitPointPayload represents input and output arguments
+// of HandleExitPointHook method.
+type ExitPointPayload struct {
+	Account     *config.Account
+	BidRequest  *openrtb2.BidRequest
+	BidResponse *openrtb2.BidResponse
+	HTTPHeaders http.Header
+	Response    any
+}

--- a/hooks/plan.go
+++ b/hooks/plan.go
@@ -19,6 +19,7 @@ const (
 	StageRawBidderResponse        Stage = "raw_bidder_response"
 	StageAllProcessedBidResponses Stage = "all_processed_bid_responses"
 	StageAuctionResponse          Stage = "auction_response"
+	StageExitPoint                Stage = "exit_point"
 )
 
 func (s Stage) String() string {
@@ -41,6 +42,7 @@ type ExecutionPlanBuilder interface {
 	PlanForRawBidderResponseStage(endpoint string, account *config.Account) Plan[hookstage.RawBidderResponse]
 	PlanForAllProcessedBidResponsesStage(endpoint string, account *config.Account) Plan[hookstage.AllProcessedBidResponses]
 	PlanForAuctionResponseStage(endpoint string, account *config.Account) Plan[hookstage.AuctionResponse]
+	PlanForExitPointStage(endpoint string, account *config.Account) Plan[hookstage.ExitPoint]
 }
 
 // Plan represents a slice of groups of hooks of a specific type grouped in the established order.
@@ -153,6 +155,16 @@ func (p PlanBuilder) PlanForAuctionResponseStage(endpoint string, account *confi
 		endpoint,
 		StageAuctionResponse,
 		p.repo.GetAuctionResponseHook,
+	)
+}
+
+func (p PlanBuilder) PlanForExitPointStage(endpoint string, account *config.Account) Plan[hookstage.ExitPoint] {
+	return getMergedPlan(
+		p.hooks,
+		account,
+		endpoint,
+		StageExitPoint,
+		p.repo.GetExitPointHook,
 	)
 }
 

--- a/hooks/repo.go
+++ b/hooks/repo.go
@@ -21,6 +21,7 @@ type HookRepository interface {
 	GetRawBidderResponseHook(id string) (hookstage.RawBidderResponse, bool)
 	GetAllProcessedBidResponsesHook(id string) (hookstage.AllProcessedBidResponses, bool)
 	GetAuctionResponseHook(id string) (hookstage.AuctionResponse, bool)
+	GetExitPointHook(id string) (hookstage.ExitPoint, bool)
 }
 
 // NewHookRepository returns a new instance of the HookRepository interface.
@@ -49,6 +50,7 @@ type hookRepository struct {
 	rawBidderResponseHooks       map[string]hookstage.RawBidderResponse
 	allProcessedBidResponseHooks map[string]hookstage.AllProcessedBidResponses
 	auctionResponseHooks         map[string]hookstage.AuctionResponse
+	exitPointHooks               map[string]hookstage.ExitPoint
 }
 
 func (r *hookRepository) GetEntrypointHook(id string) (hookstage.Entrypoint, bool) {
@@ -77,6 +79,10 @@ func (r *hookRepository) GetAllProcessedBidResponsesHook(id string) (hookstage.A
 
 func (r *hookRepository) GetAuctionResponseHook(id string) (hookstage.AuctionResponse, bool) {
 	return getHook(r.auctionResponseHooks, id)
+}
+
+func (r *hookRepository) GetExitPointHook(id string) (hookstage.ExitPoint, bool) {
+	return getHook(r.exitPointHooks, id)
 }
 
 func (r *hookRepository) add(id string, hook interface{}) error {
@@ -128,6 +134,13 @@ func (r *hookRepository) add(id string, hook interface{}) error {
 	if h, ok := hook.(hookstage.AuctionResponse); ok {
 		hasAnyHooks = true
 		if r.auctionResponseHooks, err = addHook(r.auctionResponseHooks, h, id); err != nil {
+			return err
+		}
+	}
+
+	if h, ok := hook.(hookstage.ExitPoint); ok {
+		hasAnyHooks = true
+		if r.exitPointHooks, err = addHook(r.exitPointHooks, h, id); err != nil {
 			return err
 		}
 	}

--- a/modules/builder.go
+++ b/modules/builder.go
@@ -2,7 +2,7 @@ package modules
 
 import (
 	fiftyonedegreesDevicedetection "github.com/prebid/prebid-server/v3/modules/fiftyonedegrees/devicedetection"
-	"github.com/prebid/prebid-server/v3/modules/postindustria/test_exit_point_hook"
+	"github.com/prebid/prebid-server/v3/modules/postindustria/exit_point_demo"
 	prebidOrtb2blocking "github.com/prebid/prebid-server/v3/modules/prebid/ortb2blocking"
 	prebidRulesengine "github.com/prebid/prebid-server/v3/modules/prebid/rulesengine"
 )
@@ -19,7 +19,7 @@ func builders() ModuleBuilders {
 			"rulesengine":   prebidRulesengine.Builder,
 		},
 		"postindustria": {
-			"test_exit_point_hook": test_exit_point_hook.Builder,
+			"exit_point_demo": exit_point_demo.Builder,
 		},
 	}
 }

--- a/modules/builder.go
+++ b/modules/builder.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	fiftyonedegreesDevicedetection "github.com/prebid/prebid-server/v3/modules/fiftyonedegrees/devicedetection"
+	"github.com/prebid/prebid-server/v3/modules/postindustria/test_exit_point_hook"
 	prebidOrtb2blocking "github.com/prebid/prebid-server/v3/modules/prebid/ortb2blocking"
 	prebidRulesengine "github.com/prebid/prebid-server/v3/modules/prebid/rulesengine"
 )
@@ -16,6 +17,9 @@ func builders() ModuleBuilders {
 		"prebid": {
 			"ortb2blocking": prebidOrtb2blocking.Builder,
 			"rulesengine":   prebidRulesengine.Builder,
+		},
+		"postindustria": {
+			"test_exit_point_hook": test_exit_point_hook.Builder,
 		},
 	}
 }

--- a/modules/postindustria/exit_point_demo/module.go
+++ b/modules/postindustria/exit_point_demo/module.go
@@ -1,0 +1,73 @@
+package exit_point_demo
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/prebid/prebid-server/v3/hooks/hookstage"
+	"github.com/prebid/prebid-server/v3/modules/moduledeps"
+)
+
+type (
+	Module struct{}
+)
+
+func Builder(_ json.RawMessage, _ moduledeps.ModuleDeps) (any, error) {
+	return Module{}, nil
+}
+
+func (m Module) HandleExitPointHook(
+	_ context.Context,
+	_ hookstage.ModuleInvocationContext,
+	payload hookstage.ExitPointPayload,
+) (hookstage.HookResult[hookstage.ExitPointPayload], error) {
+	moduleContext := make(hookstage.ModuleContext)
+	result := hookstage.HookResult[hookstage.ExitPointPayload]{
+		ModuleContext: moduleContext,
+	}
+
+	// this is example where custom type struct is returned
+	result.ChangeSet.AddMutation(func(payload hookstage.ExitPointPayload) (hookstage.ExitPointPayload, error) {
+		payload.HTTPHeaders = http.Header{
+			"Content-Type": []string{"application/javascript", "text/html"},
+			"Accept":       []string{"application/json", "text/html"},
+		}
+		payload.Response = nil
+		return payload, nil
+	}, hookstage.MutationUpdate)
+	//
+	//// this is example where custom type struct is returned
+	//result.ChangeSet.AddMutation(func(payload hookstage.ExitPointPayload) (hookstage.ExitPointPayload, error) {
+	//	payload.HTTPHeaders = http.Header{
+	//		"Content-Type": []string{"application/javascript", "text/html"},
+	//		"Accept":       []string{"application/json", "text/html"},
+	//	}
+	//	payload.Response = struct {
+	//		Imp     []openrtb2.Imp     `json:"imp,omitempty"`
+	//		BidID   string             `json:"bidid,omitempty"`
+	//		SeatBid []openrtb2.SeatBid `json:"seatbid,omitempty"`
+	//	}{
+	//		Imp:     payload.BidRequest.Imp,
+	//		BidID:   payload.BidResponse.BidID,
+	//		SeatBid: payload.BidResponse.SeatBid,
+	//	}
+	//	return payload, nil
+	//}, hookstage.MutationUpdate)
+
+	// this is example where json is returned
+	//result.ChangeSet.AddMutation(func(payload hookstage.ExitPointPayload) (hookstage.ExitPointPayload, error) {
+	//	payload.HTTPHeaders = http.Header{
+	//		"Content-Type": []string{"application/javascript", "text/html"},
+	//		"Accept":       []string{"application/json", "text/html"},
+	//	}
+	//	var j json.RawMessage
+	//	j, _ = sjson.SetBytes(j, "imp", "value")
+	//	j, _ = sjson.SetBytes(j, "bidid", 123)
+	//	j, _ = sjson.SetBytes(j, "seatbid", true)
+	//	payload.Response = j
+	//	return payload, nil
+	//}, hookstage.MutationUpdate)
+
+	return result, nil
+}

--- a/modules/postindustria/exit_point_demo/pbs.yaml
+++ b/modules/postindustria/exit_point_demo/pbs.yaml
@@ -1,0 +1,51 @@
+external_url: https://prebid.postindustria.com
+port: 8080
+admin_port: 8081
+
+generate_bid_id: true
+
+gdpr:
+  default_value: '0'
+
+cache:
+  hide_error_logs: true
+
+external_cache:
+  scheme: https
+  host: cache.prebid.postindustria.com
+  path: /cache
+
+stored_requests:
+  filesystem:
+    enabled: true
+    directorypath: .
+
+stored_responses:
+  filesystem:
+    enabled: true
+    directorypath: .
+
+accounts:
+  filesystem:
+    enabled: true
+    directorypath: .
+account_defaults:
+  events:
+    enabled: true
+
+hooks:
+  enabled: true
+  modules:
+    postindustria:
+      exit_point_demo:
+        enabled: true
+  host_execution_plan:
+    endpoints:
+      "/openrtb2/auction":
+        stages:
+          exit_point:
+            groups:
+              - timeout: 10
+                hook_sequence:
+                  - module_code: postindustria.exit_point_demo
+                    hook_impl_code: postindustria-exit_point_demo-exit_point

--- a/modules/postindustria/exit_point_demo/request.json
+++ b/modules/postindustria/exit_point_demo/request.json
@@ -1,0 +1,715 @@
+{
+  "test": 1,
+  "imp": [
+    {
+      "ext": {
+        "data": {
+          "adserver": {
+            "name": "gam",
+            "adslot": "/22247219933/TPS_leftbar_organic"
+          },
+          "pbadslot": "/22247219933/TPS_leftbar_organic",
+          "gpid": "/22247219933/TPS_leftbar_organic"
+        },
+        "gpid": "/22247219933/TPS_leftbar_organic",
+        "prebid": {
+          "bidder": {
+            "33across": {
+              "siteId": "dslLtIIeWr7kuOrkHcnnVW",
+              "productId": "siab"
+            },
+            "adtelligent": {
+              "aid": 876850
+            },
+            "amx": {
+              "tagId": "cHVibWF4LmNvbQ",
+              "adUnitId": "TPS_leftbar_organic"
+            },
+            "appnexus": {
+              "placementId": 32576019
+            },
+            "grid": {
+              "uid": 358102
+            },
+            "improvedigital": {
+              "publisherId": 1914,
+              "placementId": 22666288
+            },
+            "ix": {
+              "siteId": "830902",
+              "size": [
+                160,
+                600
+              ]
+            },
+            "mediafuse": {
+              "placementId": 30540588
+            },
+            "medianet": {
+              "cid": "8CU92U75D",
+              "crid": "621936156"
+            },
+            "minutemedia": {
+              "org": "01hq33rzc2my",
+              "currency": "USD",
+              "placementId": "TPS_leftbar_organic"
+            },
+            "onetag": {
+              "pubId": "642455ab8f71fec",
+              "ext": {
+                "adunit": "TPS_leftbar_organic"
+              },
+              "overwriteAdUnitCode": "TPS_leftbar_organic"
+            },
+            "openx": {
+              "unit": "556659153",
+              "delDomain": "digikulture-d.openx.net"
+            },
+            "pubmatic": {
+              "publisherId": "164752",
+              "adSlot": "TPS_leftbar_organic"
+            },
+            "richaudience": {
+              "pid": "pNCSJWp1bS",
+              "supplyType": "site"
+            },
+            "rubicon": {
+              "accountId": "26420",
+              "siteId": "551114",
+              "zoneId": "3446426"
+            },
+            "sharethrough": {
+              "pkey": "OUbFsjObhHCnrrpFXt8boLSA"
+            },
+            "smilewanted": {
+              "zoneId": "adapex.io_hb_display"
+            },
+            "sovrn": {
+              "tagid": "1242237"
+            },
+            "unruly": {
+              "siteId": 274705
+            },
+            "vidazoo": {
+              "cId": "65e72be7ac9e99bd5338904e",
+              "pId": "59ac17c192832d0011283fe3",
+              "subDomain": "exchange"
+            },
+            "yieldmo": {
+              "placementId": "2946663258737549417"
+            }
+          },
+          "adunitcode": "3e13968d-6020-4b06-97b6-42d172df415b",
+          "floors": {
+            "floorMin": 0.0091
+          }
+        }
+      },
+      "banner": {
+        "topframe": 1,
+        "format": [
+          {
+            "w": 120,
+            "h": 600
+          },
+          {
+            "w": 160,
+            "h": 600
+          }
+        ],
+        "pos": 1
+      },
+      "id": "3e13968d-6020-4b06-97b6-42d172df415b",
+      "secure": 1,
+      "bidfloor": 0.0091,
+      "bidfloorcur": "USD"
+    },
+    {
+      "ext": {
+        "data": {
+          "adserver": {
+            "name": "gam",
+            "adslot": "/22247219933/TPS_Rightbar_organic"
+          },
+          "pbadslot": "/22247219933/TPS_Rightbar_organic",
+          "gpid": "/22247219933/TPS_Rightbar_organic"
+        },
+        "gpid": "/22247219933/TPS_Rightbar_organic",
+        "prebid": {
+          "bidder": {
+            "33across": {
+              "siteId": "dIiFC8IeWr7kuOrkHcnnVW",
+              "productId": "siab"
+            },
+            "adtelligent": {
+              "aid": 876850
+            },
+            "adyoulike": {
+              "placement": "b1bd21839a876a90643b987d1826b63c"
+            },
+            "amx": {
+              "tagId": "cHVibWF4LmNvbQ",
+              "adUnitId": "TPS_Rightbar_organic"
+            },
+            "appnexus": {
+              "placementId": 32576022
+            },
+            "grid": {
+              "uid": 358105
+            },
+            "improvedigital": {
+              "publisherId": 1914,
+              "placementId": 22666291
+            },
+            "ix": {
+              "siteId": "830905",
+              "size": [
+                336,
+                280
+              ]
+            },
+            "mediafuse": {
+              "placementId": 30540588
+            },
+            "medianet": {
+              "cid": "8CU92U75D",
+              "crid": "621936156"
+            },
+            "minutemedia": {
+              "org": "01hq33rzc2my",
+              "currency": "USD",
+              "placementId": "TPS_Rightbar_organic"
+            },
+            "onetag": {
+              "pubId": "642455ab8f71fec",
+              "ext": {
+                "adunit": "TPS_Rightbar_organic"
+              },
+              "overwriteAdUnitCode": "TPS_Rightbar_organic"
+            },
+            "openx": {
+              "unit": "556659162",
+              "delDomain": "digikulture-d.openx.net"
+            },
+            "pubmatic": {
+              "publisherId": "164752",
+              "adSlot": "TPS_Rightbar_organic"
+            },
+            "richaudience": {
+              "pid": "sq5iHAWoIa",
+              "supplyType": "site"
+            },
+            "rubicon": {
+              "accountId": "26420",
+              "siteId": "551114",
+              "zoneId": "3446426"
+            },
+            "sharethrough": {
+              "pkey": "OUbFsjObhHCnrrpFXt8boLSA"
+            },
+            "smilewanted": {
+              "zoneId": "adapex.io_hb_display"
+            },
+            "sovrn": {
+              "tagid": "1242243"
+            },
+            "unruly": {
+              "siteId": 274705
+            },
+            "vidazoo": {
+              "cId": "65e72be7ac9e99bd5338904e",
+              "pId": "59ac17c192832d0011283fe3",
+              "subDomain": "exchange"
+            },
+            "yieldmo": {
+              "placementId": "2946663259635130476"
+            }
+          },
+          "adunitcode": "e17728cd-9c4a-4f9d-8d30-b0413d3191c9",
+          "floors": {
+            "floorMin": 0.0091
+          }
+        }
+      },
+      "banner": {
+        "topframe": 1,
+        "format": [
+          {
+            "w": 120,
+            "h": 600
+          },
+          {
+            "w": 160,
+            "h": 600
+          },
+          {
+            "w": 300,
+            "h": 600
+          },
+          {
+            "w": 120,
+            "h": 240
+          },
+          {
+            "w": 300,
+            "h": 250
+          },
+          {
+            "w": 336,
+            "h": 280
+          }
+        ],
+        "pos": 1
+      },
+      "id": "e17728cd-9c4a-4f9d-8d30-b0413d3191c9",
+      "secure": 1,
+      "bidfloor": 0.0091,
+      "bidfloorcur": "USD"
+    },
+    {
+      "ext": {
+        "data": {
+          "adserver": {
+            "name": "gam",
+            "adslot": "/22247219933/TPS_Anchor_bottom_organic"
+          },
+          "pbadslot": "/22247219933/TPS_Anchor_bottom_organic",
+          "gpid": "/22247219933/TPS_Anchor_bottom_organic"
+        },
+        "gpid": "/22247219933/TPS_Anchor_bottom_organic",
+        "prebid": {
+          "bidder": {
+            "33across": {
+              "siteId": "dZ55wuIeWr7kuOrkHcnnVW",
+              "productId": "siab"
+            },
+            "adtelligent": {
+              "aid": 876850
+            },
+            "adyoulike": {
+              "placement": "1185ae1676b57daff24590bd22f9df29"
+            },
+            "amx": {
+              "tagId": "cHVibWF4LmNvbQ",
+              "adUnitId": "TPS_Anchor_bottom_organic"
+            },
+            "appnexus": {
+              "placementId": 32576010
+            },
+            "grid": {
+              "uid": 358108
+            },
+            "gumgum": {
+              "zone": "fopl360q"
+            },
+            "improvedigital": {
+              "publisherId": 1914,
+              "placementId": 22666294
+            },
+            "ix": {
+              "siteId": "830908",
+              "size": [
+                728,
+                90
+              ]
+            },
+            "mediafuse": {
+              "placementId": 30540588
+            },
+            "medianet": {
+              "cid": "8CU92U75D",
+              "crid": "621936156"
+            },
+            "minutemedia": {
+              "org": "01hq33rzc2my",
+              "currency": "USD",
+              "placementId": "TPS_Anchor_bottom_organic"
+            },
+            "onetag": {
+              "pubId": "642455ab8f71fec",
+              "ext": {
+                "adunit": "TPS_Anchor_bottom_organic"
+              },
+              "overwriteAdUnitCode": "TPS_Anchor_bottom_organic"
+            },
+            "openx": {
+              "unit": "556659165",
+              "delDomain": "digikulture-d.openx.net"
+            },
+            "pubmatic": {
+              "publisherId": "164752",
+              "adSlot": "TPS_Anchor_bottom_organic"
+            },
+            "richaudience": {
+              "pid": "H7hV5sDAKQ",
+              "supplyType": "site"
+            },
+            "rubicon": {
+              "accountId": "26420",
+              "siteId": "551114",
+              "zoneId": "3446426"
+            },
+            "sharethrough": {
+              "pkey": "OUbFsjObhHCnrrpFXt8boLSA"
+            },
+            "smilewanted": {
+              "zoneId": "adapex.io_hb_display"
+            },
+            "sovrn": {
+              "tagid": "1242215"
+            },
+            "unruly": {
+              "siteId": 274705
+            },
+            "vidazoo": {
+              "cId": "65e72be7ac9e99bd5338904e",
+              "pId": "59ac17c192832d0011283fe3",
+              "subDomain": "exchange"
+            },
+            "yieldmo": {
+              "placementId": "2946663260490768495"
+            }
+          },
+          "adunitcode": "499ccda0-6ff7-4453-9b71-3bb4f9580605",
+          "floors": {
+            "floorMin": 0.0091
+          }
+        }
+      },
+      "banner": {
+        "topframe": 1,
+        "format": [
+          {
+            "w": 970,
+            "h": 90
+          },
+          {
+            "w": 728,
+            "h": 90
+          }
+        ],
+        "pos": 1
+      },
+      "id": "499ccda0-6ff7-4453-9b71-3bb4f9580605",
+      "secure": 1,
+      "bidfloor": 0.0091,
+      "bidfloorcur": "USD"
+    }
+  ],
+  "device": {
+    "w": 1920,
+    "h": 1080,
+    "dnt": 1,
+    "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0",
+    "language": "en",
+    "ext": {
+      "vpw": 1517,
+      "vph": 878
+    },
+    "ip": "208.107.230.122",
+    "sua": {
+      "source": 2,
+      "platform": {
+        "brand": "Windows",
+        "version": [
+          "10",
+          "0",
+          "0"
+        ]
+      },
+      "browsers": [
+        {
+          "brand": "Microsoft Edge",
+          "version": [
+            "131",
+            "0",
+            "2903",
+            "146"
+          ]
+        },
+        {
+          "brand": "Chromium",
+          "version": [
+            "131",
+            "0",
+            "6778",
+            "265"
+          ]
+        },
+        {
+          "brand": "Not_A Brand",
+          "version": [
+            "24",
+            "0",
+            "0",
+            "0"
+          ]
+        }
+      ],
+      "mobile": 0,
+      "model": "",
+      "architecture": "x86"
+    }
+  },
+  "regs": {
+    "ext": {
+      "gdpr": 0
+    }
+  },
+  "user": {
+    "ext": {
+      "eids": [
+        {
+          "source": "growthcode.io",
+          "uids": [
+            {
+              "atype": 1,
+              "id": "92541bfa-1df4-4abb-9967-02473f56d9ca"
+            }
+          ]
+        },
+        {
+          "source": "crwdcntrl.net",
+          "uids": [
+            {
+              "atype": 1,
+              "id": "f3df10483f69a3f845c7a233cfb84945a7027e37184a1607b2d3a948c39f044a"
+            }
+          ]
+        },
+        {
+          "source": "id5-sync.com",
+          "uids": [
+            {
+              "atype": 1,
+              "id": "%7B%22created_at%22%3A%222025-01-13T22%3A25%3A51.427311308Z%22%2C%22id5_consent%22%3Afalse%2C%22original_uid%22%3A%220%22%2C%22universal_uid%22%3A%220%22%2C%22link_type%22%3A0%2C%22cascade_needed%22%3Afalse%2C%22privacy%22%3A%7B%22jurisdiction%22%3A%22other%22%2C%22id5_consent%22%3Afalse%7D%2C%22ext%22%3A%7B%22linkType%22%3A0%2C%22pba%22%3A%220QfwHXifHMaGuaVsEmzs%2BQ%3D%3D%22%7D%2C%22ids%22%3A%7B%22id5id%22%3A%7B%22eid%22%3A%7B%22source%22%3A%22id5-sync.com%22%2C%22uids%22%3A%5B%7B%22id%22%3A%220%22%2C%22atype%22%3A1%2C%22ext%22%3A%7B%22linkType%22%3A0%2C%22pba%22%3A%220QfwHXifHMaGuaVsEmzs%2BQ%3D%3D%22%7D%7D%5D%7D%7D%7D%7D"
+            }
+          ]
+        },
+        {
+          "source": "amxdt.net",
+          "uids": [
+            {
+              "atype": 1,
+              "id": "amx*3*07b4ab0c-036c-4245-ad52-ff25b8f907ce*1667ce7c5c1edfb2bf72c69f894e596e"
+            }
+          ]
+        },
+        {
+          "source": "audigent.com",
+          "uids": [
+            {
+              "atype": 1,
+              "id": "060kje9j2g5gke77879gc7c699i8aj89hcdywm6wsqyqym22426qi2i066u4ew46s"
+            }
+          ]
+        },
+        {
+          "source": "pubcid.org",
+          "uids": [
+            {
+              "id": "3e415bdc-bfec-4f1b-9a6c-10944d45e89c",
+              "atype": 1
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "ext": {
+    "prebid": {
+      "auctiontimestamp": 1736950565863,
+      "targeting": {
+        "includewinners": true,
+        "includebidderkeys": false
+      },
+      "adServerCurrency": "USD",
+      "cache": {
+        "bids": {
+          "returnCreative": true
+        },
+        "vastxml": {
+          "returnCreative": true
+        }
+      },
+      "bidderconfig": [
+        {
+          "bidders": [
+            "unruly"
+          ],
+          "config": {
+            "ortb2": {}
+          }
+        },
+        {
+          "bidders": [
+            "vidazoo"
+          ],
+          "config": {
+            "ortb2": {}
+          }
+        },
+        {
+          "bidders": [
+            "amx"
+          ],
+          "config": {
+            "ortb2": {}
+          }
+        },
+        {
+          "bidders": [
+            "sovrn"
+          ],
+          "config": {
+            "ortb2": {}
+          }
+        },
+        {
+          "bidders": [
+            "appnexus"
+          ],
+          "config": {
+            "ortb2": {}
+          }
+        },
+        {
+          "bidders": [
+            "rise"
+          ],
+          "config": {
+            "ortb2": {}
+          }
+        },
+        {
+          "bidders": [
+            "minutemedia"
+          ],
+          "config": {
+            "ortb2": {}
+          }
+        },
+        {
+          "bidders": [
+            "richaudience"
+          ],
+          "config": {
+            "ortb2": {}
+          }
+        },
+        {
+          "bidders": [
+            "rubicon"
+          ],
+          "config": {
+            "ortb2": {}
+          }
+        },
+        {
+          "bidders": [
+            "medianet"
+          ],
+          "config": {
+            "ortb2": {}
+          }
+        },
+        {
+          "bidders": [
+            "adtelligent"
+          ],
+          "config": {
+            "ortb2": {}
+          }
+        },
+        {
+          "bidders": [
+            "pubmatic"
+          ],
+          "config": {
+            "ortb2": {}
+          }
+        }
+      ],
+      "schains": [
+        {
+          "bidders": [
+            "33across",
+            "grid",
+            "improvedigital",
+            "ix",
+            "mediafuse",
+            "onetag",
+            "openx",
+            "sharethrough",
+            "smilewanted",
+            "yieldmo",
+            "adyoulike",
+            "gumgum"
+          ],
+          "schain": {
+            "ver": "1.0",
+            "complete": 1,
+            "nodes": [
+              {
+                "asi": "adapex.io",
+                "sid": "s1605",
+                "hp": 1
+              }
+            ]
+          }
+        },
+        {
+          "bidders": [
+            "adtelligent",
+            "amx",
+            "appnexus",
+            "medianet",
+            "minutemedia",
+            "pubmatic",
+            "richaudience",
+            "rubicon",
+            "sovrn",
+            "unruly",
+            "vidazoo"
+          ],
+          "schain": {
+            "ver": "1.0",
+            "complete": 1,
+            "nodes": [
+              {
+                "asi": "pubmax.com",
+                "sid": "23045",
+                "hp": 1
+              }
+            ]
+          }
+        }
+      ],
+      "channel": {
+        "name": "pbjs",
+        "version": "v9.24.0"
+      },
+      "floors": {
+        "enabled": false,
+        "floorMin": 0.0091,
+        "floorMinCur": "USD"
+      },
+      "createtids": false
+    },
+    "tmaxmax": 2000
+  },
+  "site": {
+    "domain": "truepeoplesearch.com",
+    "publisher": {
+      "domain": "truepeoplesearch.com",
+      "id": "p-bid-account-y9eg0fEH"
+    },
+    "page": "https://www.truepeoplesearch.com/find/person/p26648nnu8249690n0lu",
+    "ref": "https://www.truepeoplesearch.com/results?name=Tonia%20Reinhart%20&citystatezip=mcville,%20nd"
+  },
+  "id": "a315272a-8478-463a-a936-d4e55717f83f",
+  "cur": [
+    "USD"
+  ],
+  "tmax": 1500
+}


### PR DESCRIPTION
## Specification

Reference: [3.3 New module stage: exit_point](https://docs.google.com/document/d/1Fkwym4EREfOdaTD8SHUODKwlj-vWpZWQa0eGUToyzPU)

**Requirements:**
- `exit_point` stage is executed right before the final Prebid Server response
- It allows customized response - both headers and body of response can be customized
- If multiple hooks mutate the response, only the last hook mutation will be executed
- Don't call exitpoint modules when we're about to return an error. Only call them when it's a 2xx return code

**Implementation:**
- Module developer receives payload with: *config.Account, *openrtb2.BidRequest, *openrtb2.BidResponse
- Module developer can create or reuse any type of object (it can be of his own making) - prebid will serialize it and return as json
- Module developer can return json.RawMessage - in this case, it will not be serialized
- Module developer can return null - in that case, initial  *openrtb2.BidResponse will be serialized and returned to the user

**Demo:**
- Demo module and sample configuration are included in this PR
- Demo location: '/modules/postindustria/demo_exit_point'
- Sample 'pbs.yaml' and 'request.json' are included

**How to run demo:**
- Comment all mutations but one in the file:  '/modules/postindustria/demo_exit_point/module.go'
- Execute post request to 'http://127.0.0.1:8080/openrtb2/auction' using curl or Postman
- You can use attached request sample '/modules/postindustria/demo_exit_point/module.go' or your own request